### PR TITLE
Harden security scanning and patch the Go toolchain

### DIFF
--- a/.github/scripts/verify-security-workflow.sh
+++ b/.github/scripts/verify-security-workflow.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+workflow="${1:-.github/workflows/security.yml}"
+go_mod="${2:-go.mod}"
+failures=0
+
+fail() {
+  printf 'security workflow policy: %s\n' "$1" >&2
+  failures=$((failures + 1))
+}
+
+shopt -s nullglob
+workflow_files=("$(dirname "$workflow")"/*.yml "$(dirname "$workflow")"/*.yaml)
+for workflow_file in "${workflow_files[@]}"; do
+  while IFS= read -r uses_line; do
+    action_ref="${uses_line#*uses: }"
+    action_ref="${action_ref%% #*}"
+    if [[ ! "$action_ref" =~ @[0-9a-f]{40}$ ]]; then
+      fail "action must be pinned to a full commit SHA in $workflow_file: $action_ref"
+    fi
+  done < <(grep -E '^[[:space:]]*(-[[:space:]]+)?uses:' "$workflow_file")
+done
+
+if grep -Eq 'go install .+@(latest|master|main)([[:space:]]|$)' "$workflow"; then
+  fail "Go security tools must use an exact module version"
+fi
+
+if grep -q -- '-no-fail' "$workflow"; then
+  fail "Gosec findings must fail the scan step"
+fi
+
+if ! grep -Eq "exit-code:[[:space:]]*['\"]?1['\"]?" "$workflow"; then
+  fail "Trivy must return a non-zero exit code for configured findings"
+fi
+
+if grep -Eq '^[[:space:]]*continue-on-error:[[:space:]]*true' "$workflow"; then
+  fail "security scanner failures must not be ignored"
+fi
+
+always_uploads="$(grep -Ec '^[[:space:]]*if:[[:space:]]*always\(\)' "$workflow" || true)"
+if (( always_uploads < 2 )); then
+  fail "both SARIF uploads must run even when their scanner reports findings"
+fi
+
+go_version="$(awk '$1 == "go" { print $2; exit }' "$go_mod")"
+IFS=. read -r go_major go_minor go_patch <<< "$go_version"
+go_patch="${go_patch:-0}"
+if (( go_major < 1 || (go_major == 1 && go_minor < 25) || (go_major == 1 && go_minor == 25 && go_patch < 12) )); then
+  fail "Go must be at least 1.25.12 to include the required standard-library security fixes"
+fi
+
+if (( failures > 0 )); then
+  exit 1
+fi
+
+printf 'security workflow policy: ok\n'

--- a/.github/workflows/build-and-update.yml
+++ b/.github/workflows/build-and-update.yml
@@ -13,9 +13,11 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Verify security workflow policy
+        run: .github/scripts/verify-security-workflow.sh
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -26,7 +28,7 @@ jobs:
       - name: Display coverage summary
         run: go tool cover -func=coverage.out
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: ./coverage.out
           fail_ci_if_error: false
@@ -37,13 +39,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           version: v2.12

--- a/.github/workflows/daily-fetch.yml
+++ b/.github/workflows/daily-fetch.yml
@@ -12,9 +12,9 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -26,7 +26,7 @@ jobs:
         run: |
           "$RUNNER_TEMP/awesome-go-rank"
       - name: Commit and push generated data
-        uses: stefanzweifel/git-auto-commit-action@v7
+        uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0
         with:
           commit_message: "chore: update ranking data"
           commit_user_name: GitHub Actions

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -18,21 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@9e6a9843d7a4a6e3e9a8539b02612c8a4aa3f889 # v2.27.1
         with:
-          args: '-no-fail -fmt sarif -out gosec.sarif ./...'
+          args: '-fmt sarif -out gosec.sarif ./...'
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         if: always()
         with:
           sarif_file: gosec.sarif
@@ -42,19 +42,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
           format: 'sarif'
           output: 'trivy-results.sarif'
+          exit-code: '1'
           severity: 'CRITICAL,HIGH'
+          version: 'v0.70.0'
 
       - name: Upload Trivy results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        if: always()
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -63,17 +66,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
 
       - name: Run govulncheck
         run: govulncheck ./...
-        continue-on-error: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devlikebear/awesome-go-rank
 
-go 1.25.0
+go 1.25.12
 
 require (
 	github.com/antchfx/htmlquery v1.3.6


### PR DESCRIPTION
## Summary
- upgrade Go from 1.25.0 to 1.25.12, eliminating 22 reachable standard-library vulnerabilities reported by govulncheck
- make Gosec, Trivy, and govulncheck fail CI on actionable findings while preserving SARIF uploads
- pin every GitHub Action and security tool to immutable versions, including the write-enabled daily update workflow
- add a policy regression check for pinned actions, scanner failure behavior, SARIF uploads, and the minimum patched Go version

## Test plan
- [x] `.github/scripts/verify-security-workflow.sh`
- [x] `actionlint`
- [x] `GOTOOLCHAIN=go1.25.12 go vet ./...`
- [x] `GOTOOLCHAIN=go1.25.12 go test -race ./...`
- [x] Gosec v2.27.1 — 0 issues
- [x] govulncheck v1.6.0 — no vulnerabilities found
- [x] `git diff --check`